### PR TITLE
Introduce `createMediaRanges`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,35 @@
 
 ## Unreleased
 
-- Rename "breakpoint" to "media range" across the library, tests and documentation to better reflect that each name describes a range between two breakpoints rather than a single breakpoint **[customer-facing]** ([#62](https://github.com/bloczjs/react-responsive/issues/62))
+Always keep those 4 sections. If empty, write `_Empty for now, to keep_`
+
+### Breaking changes
+
+_Empty for now, to keep_
+
+### Deprecations, will be removed in the next major
+
+- `MediaRangesProvider` and `MediaRangesContext` — use `createMediaRanges` instead ([#187](https://github.com/bloczjs/react-responsive/pull/187))
+- The `as` prop on the top-level `Only` ([#187](https://github.com/bloczjs/react-responsive/pull/187)) — wrap children in the element you need, or use `createMediaRanges`'s `Only`
+- The "breakpoint"-named aliases kept for backward compatibility after the rename ([#181](https://github.com/bloczjs/react-responsive/pull/181)):
+  - exports: `useBreakpoint`, `BreakpointsProvider`, `BreakpointsContext`
+  - props on `BreakpointsProvider`: `breakpoints`, `additionalBreakpoints`
+
+### Customer facing
+
+- Add `createMediaRanges` + `DEFAULT_MEDIA_RANGES`, a strongly-typed alternative to `MediaRangesProvider` ([#187](https://github.com/bloczjs/react-responsive/pull/187))
+  - `createMediaRanges(ranges)` returns a `{ useMediaRange, Only }` pair bound to the ranges you pass in — no React context, no `additionalMediaRanges` vs `mediaRanges` split
+  - The returned `useMediaRange` / `Only` validate the `on` string end-to-end: every space-separated token must match a declared range or its auto-generated `Up` / `Down` alias. Invalid input surfaces a readable TypeScript error like `Invalid media ranges: foo bar` instead of `never`
+  - The returned `Only` only forwards `children` — `as` and arbitrary forwarded props are not supported; wrap your children in whatever element you need
+  - Spread `DEFAULT_MEDIA_RANGES` when you want to keep the defaults (`xs`, `sm`, `md`, `lg`, `xl`)
+- Rename "breakpoint" to "media range" across the library, tests and documentation to better reflect that each name describes a range between two breakpoints rather than a single breakpoint ([#181](https://github.com/bloczjs/react-responsive/pull/181))
   - New exports: `useMediaRange`, `MediaRangesProvider`, `MediaRangesContext`
   - New props on `MediaRangesProvider`: `mediaRanges`, `additionalMediaRanges`
-  - The previous exports (`useBreakpoint`, `BreakpointsProvider`, `BreakpointsContext`) and props (`breakpoints`, `additionalBreakpoints`) are kept as `@deprecated` aliases for backward compatibility and will be removed in the next major
+  - Previous exports are kept but deprecated
+
+### Internal
+
+_Empty for now, to keep_
 
 ## v5
 

--- a/packages/react-responsive/README.md
+++ b/packages/react-responsive/README.md
@@ -15,22 +15,26 @@ If you need a responsive layout and adaptive components, `@blocz/react-responsiv
       1. [Default media ranges](#default-media-ranges)
       2. [Additional `Up` and `Down`](#additional-up-and-down)
       3. [Match Media Queries](#match-media-queries)
-      4. [Render as component](#render-as-component)
+      4. [Render as component (deprecated)](#render-as-component-deprecated)
    2. [Hooks](#hooks)
       1. [`useMediaRange()`](#usemediarange)
       2. [`useMediaQuery()`](#usemediaquery)
-   3. [`<MediaRangesProvider>`](#mediarangesprovider)
+   3. [`createMediaRanges()`](#createmediaranges)
+      1. [Strictly typed](#strictly-typed)
+      2. [Stricter `Only`](#stricter-only)
+      3. [Units \& direction](#units--direction)
+   4. [`<MediaRangesProvider>` (deprecated)](#mediarangesprovider-deprecated)
       1. [Add more media ranges](#add-more-media-ranges)
       2. [Change default media ranges](#change-default-media-ranges)
       3. [Units](#units)
       4. [Direction](#direction)
-   4. [Comparison to other libraries](#comparison-to-other-libraries)
-   5. [`matchMedia` polyfill](#matchmedia-polyfill)
+   5. [Comparison to other libraries](#comparison-to-other-libraries)
+   6. [`matchMedia` polyfill](#matchmedia-polyfill)
       1. [Browser](#browser)
       2. [Node](#node)
-   6. [React 16 / 17 support](#react-16--17-support)
-   7. [Deprecated APIs](#deprecated-apis)
-   8. [FAQ](#faq)
+   7. [React 16 / 17 support](#react-16--17-support)
+   8. [Deprecated APIs](#deprecated-apis)
+   9. [FAQ](#faq)
 
 ## How to use
 
@@ -125,7 +129,10 @@ const App = () => (
 
 **Note:** If you use media ranges AND matchMedia, the component will be displayed if one of the media ranges is matched **OR** if the media query is fulfilled.
 
-#### Render as component
+#### Render as component (deprecated)
+
+> ⚠️ Using the `as` prop on `Only` is **deprecated** and will be removed in v6.0.0.
+> This is not considered as type-safe
 
 If you want the `Only` components to render as another component, you can use the `as` props:
 
@@ -234,7 +241,82 @@ const App = () => {
 };
 ```
 
-### `<MediaRangesProvider>`
+### `createMediaRanges()`
+
+`createMediaRanges` is the recommended way to customize the media ranges. It returns a pair of `useMediaRange` and `Only` bound to the ranges you pass in, with end-to-end TypeScript types.
+
+```javascript
+import { createMediaRanges, DEFAULT_MEDIA_RANGES } from "@blocz/react-responsive";
+
+const { useMediaRange, Only } = createMediaRanges({
+  ...DEFAULT_MEDIA_RANGES,
+  pxRange: [263, 863, { unit: "px" }],
+  emRange: [20, 40, { unit: "em" }],
+});
+```
+
+If you want to re-use the same defaults as the top-level `Only` & `useMediaRange`, you’ll need to import & use `DEFAULT_MEDIA_RANGES`
+
+#### Strictly typed
+
+The returned `useMediaRange` accepts only the names that match the ranges you declared (plus the auto-generated `Up` and `Down` aliases). The passed string can hold a single name or a space-separated list, every media range will be typechecked:
+
+```typescript
+useMediaRange("md"); // ✅
+useMediaRange("pxRangeUp"); // ✅
+useMediaRange("mdDown"); // ✅
+useMediaRange("md pxRange"); // ✅
+useMediaRange("invalid"); // ❌ TS error
+useMediaRange("md invalid"); // ❌ TS error – "md" is fine, "invalid" is not
+```
+
+This is also true for the returned `Only`:
+
+```tsx
+<>
+  <Only
+    // ✅
+    on="md pxRange"
+  >
+    …
+  </Only>
+
+  <Only
+    // ❌ TS error
+    on="lg invalid"
+  >
+    …
+  </Only>
+</>
+```
+
+#### Stricter `Only`
+
+Contrary to its top-level counterpart, `Only` returned from `createMediaRanges` only supports `on` and `matchMedia`, no `as` prop (and no drilling additional props to `as`):
+
+```javascript
+<ul>
+  <Only on="xs">
+    <li>Only visible for extra small devices</li>
+  </Only>
+</ul>
+```
+
+#### Units & direction
+
+Each entry accepts the same shape as before: `[min, max]`, `[min, max, unit]`, or `[min, max, { unit, direction }]`:
+
+```javascript
+const { Only } = createMediaRanges({
+  pxRange: [263, 863, { unit: "px" }],
+  emRange: [20, 40, { unit: "em" }],
+  yRange: [200, 400, { direction: "height" }],
+});
+```
+
+### `<MediaRangesProvider>` (deprecated)
+
+> ⚠️ `MediaRangesProvider` is **deprecated** and will be removed in v6.0.0. Use [`createMediaRanges()`](#createmediaranges) instead.
 
 `MediaRangesProvider` defines the values of every media ranges.
 
@@ -356,13 +438,15 @@ The terminology used by this library used to be "breakpoint". It was renamed to 
 
 For backward compatibility, the previous exports are still available but marked as `@deprecated`, and will be removed in the next major release:
 
-| Deprecated                   | Replacement                  |
-| ---------------------------- | ---------------------------- |
-| `useBreakpoint`              | `useMediaRange`              |
-| `BreakpointsProvider`        | `MediaRangesProvider`        |
-| `BreakpointsContext`         | `MediaRangesContext`         |
-| `breakpoints` prop           | `mediaRanges` prop           |
-| `additionalBreakpoints` prop | `additionalMediaRanges` prop |
+| Deprecated                   | Replacement                                 |
+| ---------------------------- | ------------------------------------------- |
+| `useBreakpoint`              | `useMediaRange`                             |
+| `BreakpointsProvider`        | `MediaRangesProvider`                       |
+| `BreakpointsContext`         | `MediaRangesContext`                        |
+| `breakpoints` prop           | `mediaRanges` prop                          |
+| `additionalBreakpoints` prop | `additionalMediaRanges` prop                |
+| `MediaRangesProvider`        | [`createMediaRanges()`](#createmediaranges) |
+| `MediaRangesContext`         | [`createMediaRanges()`](#createmediaranges) |
 
 ### FAQ
 

--- a/packages/react-responsive/src/MediaRangesContext.tsx
+++ b/packages/react-responsive/src/MediaRangesContext.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 
 import { sanitize, ExposedMediaRanges, MediaRanges } from "./sanitize";
+import { DEFAULT_MEDIA_RANGES } from "./defaultMediaRanges";
 
-const defaultMediaRanges: ExposedMediaRanges = {
-  xs: [0, 575, "px"], // Extra small devices (portrait phones)
-  sm: [576, 767, "px"], // Small devices (landscape phones)
-  md: [768, 991, "px"], // Medium devices (tablets)
-  lg: [992, 1199, "px"], // Large devices (desktops)
-  xl: [1200, Infinity, "px"], // Extra large devices (large desktops)
-};
-
+/**
+ * @deprecated Use {@link createMediaRanges} instead. `MediaRangesContext` will be removed in
+ * the next major together with {@link MediaRangesProvider}.
+ */
 export const MediaRangesContext: React.Context<MediaRanges> = React.createContext<MediaRanges>(
-  sanitize(defaultMediaRanges),
+  sanitize(DEFAULT_MEDIA_RANGES),
 );
 
 interface MediaRangesProviderProps {
@@ -19,8 +16,9 @@ interface MediaRangesProviderProps {
   additionalMediaRanges?: ExposedMediaRanges;
 }
 
+/** @deprecated Use {@link createMediaRanges} instead. `MediaRangesProvider` will be removed in the next major. */
 export function MediaRangesProvider({
-  mediaRanges = defaultMediaRanges,
+  mediaRanges = DEFAULT_MEDIA_RANGES,
   additionalMediaRanges,
   children,
 }: React.PropsWithChildren<MediaRangesProviderProps>): React.ReactElement {

--- a/packages/react-responsive/src/_createMediaRanges.types.test.tsx
+++ b/packages/react-responsive/src/_createMediaRanges.types.test.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// Type-level validation for `createMediaRanges`. The hook and components below are never
+// invoked at runtime — they exist so the typecheck pass fails if the typings drift. Each
+// `@ts-expect-error` would itself error if the line below it stopped erroring.
+//
+// Symbols are exported only so `noUnusedLocals` is satisfied. Nothing here is re-exported
+// from `./index.ts`, so consumers cannot reach them.
+
+import * as React from "react";
+
+import { createMediaRanges } from "./createMediaRanges";
+import { DEFAULT_MEDIA_RANGES } from "./defaultMediaRanges";
+
+const { useMediaRange, Only } = createMediaRanges({
+  ...DEFAULT_MEDIA_RANGES,
+  pxRange: [263, 863, { unit: "px" }],
+  emRange: [20, 40, { unit: "em" }],
+});
+
+// A second factory — its keys must not be accepted by the first factory's hook / component.
+const { useMediaRange: useOtherMediaRange } = createMediaRanges({
+  alpha: [0, 100],
+  beta: [100, 200],
+});
+
+function useTypeChecks(): boolean {
+  useMediaRange("xs");
+  useMediaRange("md");
+  useMediaRange("pxRange");
+  useMediaRange("emRange");
+
+  useMediaRange("xsUp");
+  useMediaRange("xsDown");
+  useMediaRange("pxRangeUp");
+  useMediaRange("pxRangeDown");
+  useMediaRange("emRangeUp");
+  useMediaRange("emRangeDown");
+
+  useMediaRange("sm md");
+  useMediaRange("xs sm md lg xl");
+  useMediaRange("md pxRange emRangeDown");
+  useMediaRange("pxRangeUp emRangeDown");
+
+  // @ts-expect-error – "invalid" is not a declared range
+  useMediaRange("invalid");
+  // @ts-expect-error – typo in declared name
+  useMediaRange("MD");
+  // @ts-expect-error – empty string is not a valid range name
+  useMediaRange("");
+  // @ts-expect-error – "pxRangeSide" is neither a key nor an Up/Down alias
+  useMediaRange("pxRangeSide");
+  // @ts-expect-error – only Up/Down aliases are generated, not "Mid"
+  useMediaRange("mdMid");
+
+  // @ts-expect-error – invalid token at start
+  useMediaRange("invalid md");
+  // @ts-expect-error – invalid token at end
+  useMediaRange("md invalid");
+  // @ts-expect-error – invalid token in the middle
+  useMediaRange("md invalid lg");
+  // @ts-expect-error – every token must be valid
+  useMediaRange("invalid foo bar");
+
+  // @ts-expect-error – "alpha" was declared on a different factory
+  useMediaRange("alpha");
+  // @ts-expect-error – "beta" was declared on a different factory
+  useMediaRange("beta md");
+
+  useOtherMediaRange("alpha");
+  useOtherMediaRange("alpha beta");
+  // @ts-expect-error – "md" is not declared on the other factory
+  useOtherMediaRange("md");
+  // @ts-expect-error – "pxRange" is not declared on the other factory
+  useOtherMediaRange("pxRange");
+
+  // @ts-expect-error – non-literal `string` is rejected
+  useMediaRange("md" as string);
+
+  // @ts-expect-error – `on` is required
+  useMediaRange();
+  // @ts-expect-error – undefined is not a valid token list
+  useMediaRange(undefined);
+
+  // useMediaRange returns boolean
+  return useMediaRange("md");
+}
+
+function OnlyValid(): React.ReactElement {
+  return (
+    <React.Fragment>
+      <Only on="md">ok</Only>
+      <Only on="pxRange">ok</Only>
+      <Only on="md pxRangeDown">ok</Only>
+      <Only on="xsUp lg">ok</Only>
+      <Only matchMedia="(min-width: 500px)">ok</Only>
+      <Only on="md" matchMedia="(orientation: landscape)">
+        ok
+      </Only>
+    </React.Fragment>
+  );
+}
+
+function OnlyInvalid(): React.ReactElement {
+  return (
+    <React.Fragment>
+      <Only
+        // @ts-expect-error – "invalid" is not a declared range
+        on="invalid"
+      >
+        no
+      </Only>
+      <Only
+        // @ts-expect-error – one bad token in the list
+        on="md invalid"
+      >
+        no
+      </Only>
+      <Only
+        // @ts-expect-error – "alpha" leaks from another factory
+        on="alpha"
+      >
+        no
+      </Only>
+      <Only
+        on="md"
+        // @ts-expect-error – `as` was dropped on the factory-generated Only
+        as="li"
+      >
+        no
+      </Only>
+      <Only
+        on="md"
+        // @ts-expect-error – arbitrary forwarded props were dropped on the factory-generated Only
+        className="x"
+      >
+        no
+      </Only>
+    </React.Fragment>
+  );
+}

--- a/packages/react-responsive/src/_useInternalMediaRange.ts
+++ b/packages/react-responsive/src/_useInternalMediaRange.ts
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+import { MediaRanges } from "./sanitize";
+import { mediaQueryBuilder } from "./mediaQueryBuilder";
+import { useMediaQuery } from "./useMediaQuery";
+
+export function useInternalMediaRange(mediaRanges: MediaRanges, on: string | undefined): boolean {
+  const toMediaQuery = React.useMemo(() => mediaQueryBuilder(mediaRanges), [mediaRanges]);
+  const mediaQuery = React.useMemo(() => toMediaQuery(on), [toMediaQuery, on]);
+  return useMediaQuery(mediaQuery || "-");
+}

--- a/packages/react-responsive/src/_validateMediaRanges.ts
+++ b/packages/react-responsive/src/_validateMediaRanges.ts
@@ -1,0 +1,31 @@
+import { ExposedMediaRanges } from "./sanitize";
+
+type MediaRangeKey<T extends ExposedMediaRanges> = Extract<keyof T, string>;
+
+export type ValidMediaRangeName<T extends ExposedMediaRanges> =
+  | MediaRangeKey<T>
+  | `${MediaRangeKey<T>}Up`
+  | `${MediaRangeKey<T>}Down`;
+
+type CollectInvalidMediaRanges<T extends ExposedMediaRanges, S extends string> = S extends `${infer Head} ${infer Tail}`
+  ? Head extends ValidMediaRangeName<T>
+    ? CollectInvalidMediaRanges<T, Tail>
+    : CollectInvalidMediaRanges<T, Tail> extends infer Rest extends string
+      ? Rest extends ""
+        ? Head
+        : `${Head} ${Rest}`
+      : never
+  : S extends ""
+    ? ""
+    : S extends ValidMediaRangeName<T>
+      ? ""
+      : S;
+
+export type ValidatedMediaRangeString<T extends ExposedMediaRanges, S extends string> =
+  CollectInvalidMediaRanges<T, S> extends infer Invalid extends string
+    ? Invalid extends ""
+      ? S extends ""
+        ? "Invalid media range: empty string"
+        : S
+      : `Invalid media ranges: ${Invalid}`
+    : never;

--- a/packages/react-responsive/src/_validateMediaRanges.types.test.ts
+++ b/packages/react-responsive/src/_validateMediaRanges.types.test.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// Type-level validation for `validateMediaRanges`. The assertions below lock the exact
+// error-message format so a regression in the typing surfaces here at typecheck time.
+//
+// Symbols are exported only so `noUnusedLocals` is satisfied. Nothing here is re-exported
+// from `./index.ts`, so consumers cannot reach them.
+
+import { DEFAULT_MEDIA_RANGES } from "./defaultMediaRanges";
+import { type ValidatedMediaRangeString } from "./_validateMediaRanges";
+
+type Ranges = typeof DEFAULT_MEDIA_RANGES & {
+  pxRange: [263, 863, { unit: "px" }];
+};
+type AssertEq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+const validSingle: AssertEq<ValidatedMediaRangeString<Ranges, "md">, "md"> = true;
+const validMulti: AssertEq<ValidatedMediaRangeString<Ranges, "md pxRange">, "md pxRange"> = true;
+const invalidSingle: AssertEq<ValidatedMediaRangeString<Ranges, "foo">, "Invalid media ranges: foo"> = true;
+const invalidMixed: AssertEq<ValidatedMediaRangeString<Ranges, "foo md bar">, "Invalid media ranges: foo bar"> = true;
+const invalidEmpty: AssertEq<ValidatedMediaRangeString<Ranges, "">, "Invalid media range: empty string"> = true;

--- a/packages/react-responsive/src/createMediaRanges.tsx
+++ b/packages/react-responsive/src/createMediaRanges.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { ExposedMediaRanges, MediaRanges, sanitize } from "./sanitize";
+import { ValidatedMediaRangeString } from "./_validateMediaRanges";
+import { useInternalMediaRange } from "./_useInternalMediaRange";
+import { useMediaQuery } from "./useMediaQuery";
+
+interface OnlyProps<T extends ExposedMediaRanges, S extends string> {
+  matchMedia?: string;
+  on?: ValidatedMediaRangeString<T, S>;
+}
+
+interface CustomMediaRanges<T extends ExposedMediaRanges> {
+  useMediaRange: <S extends string>(on: ValidatedMediaRangeString<T, S>) => boolean;
+  Only: <S extends string>(props: React.PropsWithChildren<OnlyProps<T, S>>) => React.ReactElement | null;
+}
+
+export function createMediaRanges<T extends ExposedMediaRanges>(mediaRanges: T): CustomMediaRanges<T> {
+  const sanitized: MediaRanges = sanitize(mediaRanges);
+
+  const useMediaRange: CustomMediaRanges<T>["useMediaRange"] = (on) => useInternalMediaRange(sanitized, on);
+
+  const Only: CustomMediaRanges<T>["Only"] = ({ matchMedia, on, children }) => {
+    const matchOn = useInternalMediaRange(sanitized, on);
+    const matchQuery = useMediaQuery(matchMedia || "-");
+    const isShown = matchOn || matchQuery;
+
+    if (!isShown) {
+      return null;
+    }
+
+    return <React.Fragment>{children}</React.Fragment>;
+  };
+
+  return { useMediaRange, Only };
+}

--- a/packages/react-responsive/src/defaultMediaRanges.ts
+++ b/packages/react-responsive/src/defaultMediaRanges.ts
@@ -1,0 +1,15 @@
+import { ExposedMediaRange } from "./sanitize";
+
+export const DEFAULT_MEDIA_RANGES: {
+  xs: ExposedMediaRange;
+  sm: ExposedMediaRange;
+  md: ExposedMediaRange;
+  lg: ExposedMediaRange;
+  xl: ExposedMediaRange;
+} = {
+  xs: [0, 575, "px"], // Extra small devices (portrait phones)
+  sm: [576, 767, "px"], // Small devices (landscape phones)
+  md: [768, 991, "px"], // Medium devices (tablets)
+  lg: [992, 1199, "px"], // Large devices (desktops)
+  xl: [1200, Infinity, "px"], // Extra large devices (large desktops)
+};

--- a/packages/react-responsive/src/index.ts
+++ b/packages/react-responsive/src/index.ts
@@ -8,4 +8,6 @@ export {
 export { Only } from "./Only";
 export { useMediaRange, useBreakpoint } from "./useMediaRange";
 export { useMediaQuery } from "./useMediaQuery";
-export { type Units } from "./sanitize";
+export { createMediaRanges } from "./createMediaRanges";
+export { DEFAULT_MEDIA_RANGES } from "./defaultMediaRanges";
+export type { Units } from "./sanitize";

--- a/packages/react-responsive/src/useMediaRange.ts
+++ b/packages/react-responsive/src/useMediaRange.ts
@@ -1,18 +1,11 @@
 import * as React from "react";
 
 import { MediaRangesContext } from "./MediaRangesContext";
-
-import { mediaQueryBuilder } from "./mediaQueryBuilder";
-
-import { useMediaQuery } from "./useMediaQuery";
+import { useInternalMediaRange } from "./_useInternalMediaRange";
 
 export function useMediaRange(on?: string): boolean {
   const mediaRanges = React.useContext(MediaRangesContext);
-  const toMediaQuery = React.useMemo(() => mediaQueryBuilder(mediaRanges), [mediaRanges]);
-
-  const mediaQuery = React.useMemo(() => toMediaQuery(on), [toMediaQuery, on]);
-
-  return useMediaQuery(mediaQuery || "-");
+  return useInternalMediaRange(mediaRanges, on);
 }
 
 /** @deprecated Use {@link useMediaRange} instead. */

--- a/packages/react-responsive/tsconfig.json
+++ b/packages/react-responsive/tsconfig.json
@@ -16,7 +16,6 @@
     "strictFunctionTypes": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/tests/src/__tests__/createMediaRanges.tsx
+++ b/packages/tests/src/__tests__/createMediaRanges.tsx
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { cleanup, setMedia } from "mock-match-media";
+
+import {
+  createMediaRanges,
+  DEFAULT_MEDIA_RANGES,
+} from "@blocz/react-responsive";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("createMediaRanges", () => {
+  it("returns a typed useMediaRange that matches when the viewport is in the named range", () => {
+    const { useMediaRange } = createMediaRanges({
+      ...DEFAULT_MEDIA_RANGES,
+      pxRange: [263, 863, { unit: "px" }],
+      emRange: [20, 40, { unit: "em" }],
+    });
+
+    setMedia({ width: 800 });
+
+    let probedMd: boolean | undefined;
+    let probedPxRange: boolean | undefined;
+    let probedXs: boolean | undefined;
+    const Probe = () => {
+      probedMd = useMediaRange("md");
+      probedPxRange = useMediaRange("pxRange");
+      probedXs = useMediaRange("xs");
+      return null;
+    };
+    render(<Probe />);
+
+    expect(probedMd).toBe(true);
+    expect(probedPxRange).toBe(true);
+    expect(probedXs).toBe(false);
+  });
+
+  it("supports the auto-generated Up / Down aliases", () => {
+    const { useMediaRange } = createMediaRanges(
+      DEFAULT_MEDIA_RANGES,
+    );
+
+    setMedia({ width: 1000 });
+
+    let probedMdUp: boolean | undefined;
+    let probedMdDown: boolean | undefined;
+    let probedXsUp: boolean | undefined;
+    const Probe = () => {
+      probedMdUp = useMediaRange("mdUp");
+      probedMdDown = useMediaRange("mdDown");
+      probedXsUp = useMediaRange("xsUp");
+      return null;
+    };
+    render(<Probe />);
+
+    expect(probedMdUp).toBe(true);
+    expect(probedMdDown).toBe(false);
+    expect(probedXsUp).toBe(true);
+  });
+
+  it("supports space-separated combinations", () => {
+    const { useMediaRange } = createMediaRanges(
+      DEFAULT_MEDIA_RANGES,
+    );
+
+    setMedia({ width: 800 });
+
+    let probedSmOrMd: boolean | undefined;
+    let probedSmOrLg: boolean | undefined;
+    const Probe = () => {
+      probedSmOrMd = useMediaRange("sm md");
+      probedSmOrLg = useMediaRange("sm lg");
+      return null;
+    };
+    render(<Probe />);
+
+    expect(probedSmOrMd).toBe(true);
+    expect(probedSmOrLg).toBe(false);
+  });
+
+  it("is isolated from MediaRangesProvider (it has its own ranges)", () => {
+    const { useMediaRange } = createMediaRanges({
+      custom: [400, 800],
+    });
+
+    setMedia({ width: 600 });
+
+    let probedCustom: boolean | undefined;
+    const Probe = () => {
+      probedCustom = useMediaRange("custom");
+      return null;
+    };
+    render(<Probe />);
+
+    expect(probedCustom).toBe(true);
+  });
+
+  describe("Only", () => {
+    it("renders children inside a Fragment when the range matches", () => {
+      const { Only } = createMediaRanges(
+        DEFAULT_MEDIA_RANGES,
+      );
+
+      setMedia({ width: 800 });
+
+      const { container } = render(
+        <div>
+          <Only on="md">visible</Only>
+          <Only on="xs">hidden</Only>
+        </div>,
+      );
+
+      expect(container.textContent).toBe("visible");
+    });
+
+    it("renders when only matchMedia matches", () => {
+      const { Only } = createMediaRanges(
+        DEFAULT_MEDIA_RANGES,
+      );
+
+      setMedia({ width: 1000 });
+
+      const { container } = render(
+        <div>
+          <Only matchMedia="(min-width: 500px)">
+            visible
+          </Only>
+          <Only matchMedia="(max-width: 100px)">
+            hidden
+          </Only>
+        </div>,
+      );
+
+      expect(container.textContent).toBe("visible");
+    });
+  });
+
+  // Type-level checks live in `./createMediaRanges.types.test.tsx`.
+});

--- a/packages/tests/src/__tests__/esm.util.mjs
+++ b/packages/tests/src/__tests__/esm.util.mjs
@@ -2,4 +2,9 @@
 import * as ReactResponsive from "@blocz/react-responsive";
 import packageJSON from "@blocz/react-responsive/package.json" with { type: "json" };
 
-console.log("Didn’t crash");
+const shape = {};
+for (const key of Object.keys(ReactResponsive)) {
+  shape[key] = typeof ReactResponsive[key];
+}
+// The stdout is used in resolver.ts
+console.log(JSON.stringify(shape));

--- a/packages/tests/src/__tests__/resolver.ts
+++ b/packages/tests/src/__tests__/resolver.ts
@@ -102,6 +102,10 @@ describe("built files", () => {
     expect(typeof exposed.Only).toBe("function");
     expect(typeof exposed.useMediaRange).toBe("function");
     expect(typeof exposed.useMediaQuery).toBe("function");
+    expect(typeof exposed.createMediaRanges).toBe(
+      "function",
+    );
+    expect(exposed.DEFAULT_MEDIA_RANGES).toBeDefined();
     expect(typeof exposed.MediaRangesProvider).toBe(
       "function",
     );

--- a/packages/tests/src/__tests__/resolver.ts
+++ b/packages/tests/src/__tests__/resolver.ts
@@ -4,6 +4,31 @@ import * as vm from "vm";
 import { existsSync, readFileSync } from "fs";
 import * as React from "react";
 
+// Shape every published build must expose: export name → `typeof` value.
+const EXPECTED_SHAPE: Record<string, string> = {
+  Only: "function",
+  useMediaRange: "function",
+  useMediaQuery: "function",
+  createMediaRanges: "function",
+  DEFAULT_MEDIA_RANGES: "object",
+  // Deprecated aliases must still be exposed for backward compatibility.
+  MediaRangesProvider: "function",
+  MediaRangesContext: "object",
+  useBreakpoint: "function",
+  BreakpointsProvider: "function",
+  BreakpointsContext: "object",
+};
+
+const toShape = (
+  exposed: Record<string, unknown>,
+): Record<string, string> => {
+  const shape: Record<string, string> = {};
+  for (const key of Object.keys(exposed)) {
+    shape[key] = typeof exposed[key];
+  }
+  return shape;
+};
+
 describe("Important files should be resolvable", () => {
   it("should work in a CJS context", () => {
     expect(
@@ -12,15 +37,6 @@ describe("Important files should be resolvable", () => {
     expect(
       require.resolve("@blocz/react-responsive/package.json"),
     ).not.toBeNull();
-  });
-
-  it("should work in a ESM context", () => {
-    expect(
-      execSync("node ./esm.util.mjs", {
-        cwd: __dirname,
-        encoding: "utf-8",
-      }),
-    ).toBe("Didn’t crash\n");
   });
 });
 
@@ -80,8 +96,33 @@ describe("built files", () => {
 
     expect(cts).toBe(mts);
   });
+});
 
-  it("should expose the UMD build as window['@blocz/react-responsive']", () => {
+describe("exposed exports", () => {
+  it("CJS build exposes all expected symbols", () => {
+    const cjs =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("@blocz/react-responsive") as Record<
+        string,
+        unknown
+      >;
+    expect(toShape(cjs)).toEqual(EXPECTED_SHAPE);
+  });
+
+  it("ESM build exposes all expected symbols", () => {
+    const output = execSync("node ./esm.util.mjs", {
+      cwd: __dirname,
+      encoding: "utf-8",
+    });
+    const shape = JSON.parse(output) as Record<
+      string,
+      string
+    >;
+
+    expect(shape).toEqual(EXPECTED_SHAPE);
+  });
+
+  it("UMD build exposes all expected symbols as window['@blocz/react-responsive']", () => {
     const BRRPath = path.dirname(
       require.resolve("@blocz/react-responsive/package.json"),
     );
@@ -99,22 +140,6 @@ describe("built files", () => {
       "@blocz/react-responsive"
     ] as Record<string, unknown>;
     expect(exposed).toBeDefined();
-    expect(typeof exposed.Only).toBe("function");
-    expect(typeof exposed.useMediaRange).toBe("function");
-    expect(typeof exposed.useMediaQuery).toBe("function");
-    expect(typeof exposed.createMediaRanges).toBe(
-      "function",
-    );
-    expect(exposed.DEFAULT_MEDIA_RANGES).toBeDefined();
-    // Deprecated aliases must still be exposed for backward compatibility.
-    expect(typeof exposed.MediaRangesProvider).toBe(
-      "function",
-    );
-    expect(exposed.MediaRangesContext).toBeDefined();
-    expect(typeof exposed.useBreakpoint).toBe("function");
-    expect(typeof exposed.BreakpointsProvider).toBe(
-      "function",
-    );
-    expect(exposed.BreakpointsContext).toBeDefined();
+    expect(toShape(exposed)).toEqual(EXPECTED_SHAPE);
   });
 });

--- a/packages/tests/src/__tests__/resolver.ts
+++ b/packages/tests/src/__tests__/resolver.ts
@@ -106,11 +106,11 @@ describe("built files", () => {
       "function",
     );
     expect(exposed.DEFAULT_MEDIA_RANGES).toBeDefined();
+    // Deprecated aliases must still be exposed for backward compatibility.
     expect(typeof exposed.MediaRangesProvider).toBe(
       "function",
     );
     expect(exposed.MediaRangesContext).toBeDefined();
-    // Deprecated aliases must still be exposed for backward compatibility.
     expect(typeof exposed.useBreakpoint).toBe("function");
     expect(typeof exposed.BreakpointsProvider).toBe(
       "function",


### PR DESCRIPTION
Introduce `createMediaRanges` that is a replacement for `MediaRangesProvider` with:
- stricter TS behavior,
- allowing multiple "context" (not React context) to live together in the same app


Deprecations:
- `MediaRangesProvider`
- On `Only`, the `as` prop


See https://github.com/bloczjs/react-responsive/issues/182

Resolves https://github.com/bloczjs/react-responsive/issues/184 & fixes https://github.com/bloczjs/react-responsive/issues/63